### PR TITLE
rename outbox generator

### DIFF
--- a/lib/active_outbox.rb
+++ b/lib/active_outbox.rb
@@ -1,5 +1,5 @@
 require 'active_outbox/configuration'
 require 'active_outbox/errors'
 require 'active_outbox/outboxable'
-require 'active_outbox/generators/outbox_generator'
+require 'active_outbox/generators/active_outbox_generator'
 require 'active_outbox/railtie' if defined?(Rails::Railtie)

--- a/lib/active_outbox/generators/active_outbox_generator.rb
+++ b/lib/active_outbox/generators/active_outbox_generator.rb
@@ -2,7 +2,7 @@ require 'rails'
 require 'rails/generators'
 require 'rails/generators/active_record'
 
-class OutboxGenerator < ActiveRecord::Generators::Base
+class ActiveOutboxGenerator < ActiveRecord::Generators::Base
   source_root File.expand_path("../templates", __FILE__)
 
   class_option :root_components_path, type: :string, default: Rails.root


### PR DESCRIPTION
Rename the file generator with the same name as the gem name to allow the final user to use the generator without complexity

[notion task](https://www.notion.so/rootstrap/Change-outbox_generator-to-active_outbox_generator-c0a5533ce1fd4778bac3613ec18e2604?pvs=4)