### PR TITLE
Spec for outbox class not found error

### DIFF
--- a/spec/lib/active_outbox/outboxable_spec.rb
+++ b/spec/lib/active_outbox/outboxable_spec.rb
@@ -57,6 +57,15 @@ RSpec.describe ActiveOutbox::Outboxable do
     subject(:save_instance) { fake_model_instance.save }
 
     context 'when record is created' do
+      context 'when the ActiveOutbox configuration is not set' do
+        before do
+          allow(ActiveOutbox.configuration).to receive(:outbox_mapping).and_return({ 'default' => nil })
+        end
+
+        include_examples 'raises an error and does not create neither the record nor the outbox record',
+                         ActiveOutbox::OutboxClassNotFoundError
+      end
+
       context 'when outbox record is created' do
         let(:event) { 'FAKE_MODEL_CREATED' }
 


### PR DESCRIPTION
This PR is to add a spec for raising `ActiveOutbox::OutboxClassNotFoundError` when the ActiveOutbox configuration is not set under `config/initializers/active_outbox.rb` with the default outbox class