### PR TITLE
Fix migration constraints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,10 +16,10 @@ Gemspec/RequireMFA:
   Enabled: false
 
 Metrics/MethodLength:
-  Max: 12
+  Max: 25
 
 Layout/EndAlignment:
-  EnforcedStyle: start_of_line
+  EnforcedStyleAlignWith: start_of_line
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,10 @@ Gemspec/RequireMFA:
   Enabled: false
 
 Metrics/MethodLength:
-  Max: 25
+  Max: 50
+
+Metrics/AbcSize:
+  Enabled: false
 
 Layout/EndAlignment:
   EnforcedStyleAlignWith: start_of_line

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,11 +18,17 @@ Gemspec/RequireMFA:
 Metrics/MethodLength:
   Max: 12
 
+Layout/EndAlignment:
+  EnforcedStyle: start_of_line
+
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
 RSpec/MultipleMemoizedHelpers:
-  Max: 7
+  Max: 10
 
 RSpec/NestedGroups:
-  Max: 4
+  Max: 7
 
 Style/Documentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,4 @@ gem 'rubocop', '~> 1.56.3', require: false
 gem 'rubocop-rspec', '~> 2.24.1', require: false
 gem 'simplecov', '~> 0.22.0'
 gem 'sqlite3', '1.4.2'
+gem 'super_diff', '~> 0.10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     ast (2.4.2)
+    attr_extras (7.1.0)
     base64 (0.1.1)
     builder (3.2.4)
     byebug (11.1.3)
@@ -125,10 +126,13 @@ GEM
     nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    optimist (3.1.0)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    patience_diff (1.2.0)
+      optimist (~> 3.0)
     pg (1.5.4)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -225,6 +229,10 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
+    super_diff (0.10.0)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
     thor (1.3.0)
     timeout (0.4.0)
     tzinfo (2.0.6)
@@ -252,6 +260,7 @@ DEPENDENCIES
   rubocop-rspec (~> 2.24.1)
   simplecov (~> 0.22.0)
   sqlite3 (= 1.4.2)
+  super_diff (~> 0.10.0)
 
 BUNDLED WITH
    2.4.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_outbox (0.1.1)
+    active_outbox (0.1.2)
       dry-configurable (~> 1.0)
       rails (>= 6.1)
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ gem install active_outbox
 
 ## Usage
 ### Setup
-Create an initializer under `config/initializers/active_outbox.rb` and setup the default outbox class to the new `Outbox` model you just created.
+Create an initializer under `config/initializers/active_outbox.rb` and setup the default outbox class to the `Outbox` model you will create in the next step.
 ```bash
 rails g active_outbox:install
 ```
-After creating the initializer, create an `Outbox` table using the provided generator and corresponding model. Any model name can be passed as an argument but if empty it will default to just `Outobx`. The generated table name will be `model_name_outboxes`.
+After creating the initializer, create an `Outbox` table using the provided generator and corresponding model. Any model name can be passed as an argument but if empty it will default to just `outboxes`. The generated table name will be `model_name_outboxes`.
 ```bash
 rails g active_outbox:model <optional model_name>
 ```

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ If you want to persist a custom event other than the provided base events, you c
 user.save(outbox_event: 'YOUR_CUSTOM_EVENT')
 ```
 ## Advanced Usage
+### Supporting UUIDs
+By default our Outbox migration has an `aggregate_identifier` field which serves the purpose of identifying which record was involved in the event emission. We default to integer IDs, but if you're using UUIDs as a primary key for your records you have to adjust the migrations accordingly. To do so just run the model generator with the `--uuid` flag.
+```bash
+rails g active_outbox:model <optional model_name> --uuid
+```
+### Multiple Outbox mappings
 If more granularity is desired multiple `Outbox` classes can be configured. After creating the needed `Outbox` classes for each module you can specify multiple mappings in the initializer.
 ```ruby
 # frozen_string_literal: true
@@ -73,8 +79,8 @@ If more granularity is desired multiple `Outbox` classes can be configured. Afte
 Rails.application.reloader.to_prepare do
   ActiveOutbox.configure do |config|
     config.outbox_mapping = {
-      'Member' => 'Member::Outbox',
-      'UserAccess' => 'UserAccess::Outbox'
+      'member' => 'Member::Outbox',
+      'user_access' => 'UserAccess::Outbox'
     }
   end
 end

--- a/active_outbox.gemspec
+++ b/active_outbox.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.files                 = Dir['LICENSE.txt', 'README.md', 'lib/**/*', 'lib/active_outbox.rb']
   spec.name                  = 'active_outbox'
   spec.summary               = 'A Transactional Outbox implementation for ActiveRecord'
-  spec.version               = '0.1.1'
+  spec.version               = '0.1.2'
 
   spec.email                 = 'guillermoaguirre1@gmail.com'
   spec.executables           = ['outbox']

--- a/lib/active_outbox/outboxable.rb
+++ b/lib/active_outbox/outboxable.rb
@@ -56,8 +56,8 @@ module ActiveOutbox
 
     def outbox_model
       module_parent = self.class.module_parent
-
-      unless module_parent.const_defined?('OUTBOX_MODEL')
+      # sets _inherit_ option to false so it doesn't lookup in ancestors for the constant
+      unless module_parent.const_defined?('OUTBOX_MODEL', false)
         outbox_model = outbox_model_name!.safe_constantize
         module_parent.const_set('OUTBOX_MODEL', outbox_model)
       end

--- a/lib/active_outbox/outboxable.rb
+++ b/lib/active_outbox/outboxable.rb
@@ -100,8 +100,10 @@ module ActiveOutbox
       when :destroy
         { before: as_json, after: nil }
       else
-        raise ActiveRecord::RecordNotSaved.new("Failed to create Outbox payload for #{self.class.name}: #{send(self.class.primary_key)}",
-          self)
+        raise ActiveRecord::RecordNotSaved.new(
+          "Failed to create Outbox payload for #{self.class.name}: #{send(self.class.primary_key)}",
+          self
+        )
       end
     end
   end

--- a/lib/active_outbox/outboxable.rb
+++ b/lib/active_outbox/outboxable.rb
@@ -44,13 +44,12 @@ module ActiveOutbox
     def create_outbox!(action, event_name)
       outbox = outbox_model.new(
         aggregate: self.class.name,
-        aggregate_identifier: try(:identifier) || id,
+        aggregate_identifier: send(self.class.primary_key),
         event: @outbox_event || event_name,
         identifier: SecureRandom.uuid,
         payload: formatted_payload(action)
       )
       @outbox_event = nil
-
       handle_outbox_errors(outbox) if outbox.invalid?
       outbox.save!
     end
@@ -71,9 +70,9 @@ module ActiveOutbox
     end
 
     def namespace_outbox_mapping
-      namespace = self.class.name.split('/').first
+      namespace = self.class.module_parent.name.underscore
 
-      ActiveOutbox.config.outbox_mapping[namespace&.underscore]
+      ActiveOutbox.config.outbox_mapping[namespace]
     end
 
     def default_outbox_mapping
@@ -101,8 +100,8 @@ module ActiveOutbox
       when :destroy
         { before: as_json, after: nil }
       else
-        raise ActiveRecord::RecordNotSaved.new("Failed to create Outbox payload for #{self.class.name}: #{identifier}",
-                                               self)
+        raise ActiveRecord::RecordNotSaved.new("Failed to create Outbox payload for #{self.class.name}: #{send(self.class.primary_key)}",
+          self)
       end
     end
   end

--- a/lib/generators/active_outbox/model/model_generator.rb
+++ b/lib/generators/active_outbox/model/model_generator.rb
@@ -20,8 +20,13 @@ module ActiveOutbox
       desc 'Creates the Outbox model migration'
 
       argument :model_name, type: :string, default: ''
-      class_option :component_path, type: :string, desc: 'Indicates where to create the outbox migration'
-      class_option :uuid, type: :boolean, default: false, desc: 'Use UUID to identify aggregate records in events. Defaults to ID'
+      class_option :component_path,
+        type: :string,
+        desc: 'Indicates where to create the outbox migration'
+      class_option :uuid,
+        type: :boolean,
+        default: false,
+        desc: 'Use UUID to identify aggregate records in events. Defaults to ID'
 
       def create_migration_file
         migration_path = "#{root_path}/db/migrate"

--- a/lib/generators/active_outbox/model/model_generator.rb
+++ b/lib/generators/active_outbox/model/model_generator.rb
@@ -21,6 +21,7 @@ module ActiveOutbox
 
       argument :model_name, type: :string, default: ''
       class_option :component_path, type: :string, desc: 'Indicates where to create the outbox migration'
+      class_option :uuid, type: :boolean, default: false, desc: 'Use UUID to identify aggregate records in events. Defaults to ID'
 
       def create_migration_file
         migration_path = "#{root_path}/db/migrate"
@@ -41,6 +42,10 @@ module ActiveOutbox
 
       def table_name
         model_name.blank? ? 'outboxes' : "#{model_name}_outboxes"
+      end
+
+      def aggregate_identifier_type
+        options['uuid'].present? ? ActiveOutbox::AdapterHelper.uuid_type : 'integer'
       end
     end
   end

--- a/lib/generators/active_outbox/templates/migration.rb
+++ b/lib/generators/active_outbox/templates/migration.rb
@@ -7,7 +7,7 @@ class ActiveOutboxCreate<%= table_name.camelize %> < ActiveRecord::Migration<%= 
       t.string :event, null: false
       t.<%= ActiveOutbox::AdapterHelper.json_type %> :payload
       t.string :aggregate, null: false
-      t.<%= ActiveOutbox::AdapterHelper.uuid_type %> :aggregate_identifier, null: false, index: true
+      t.<%= aggregate_identifier_type %> :aggregate_identifier, null: false, index: true
 
       t.timestamps
     end

--- a/spec/lib/active_outbox/generators/model_generator_spec.rb
+++ b/spec/lib/active_outbox/generators/model_generator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ActiveOutbox::Generators::ModelGenerator, type: :generator do
     let(:migration_file_path) do
       "#{destination_root}/db/migrate/#{timestamp_of_migration}_active_outbox_create_outboxes.rb"
     end
-
+    
     context 'without root_component_path' do
       before do
         allow(Rails).to receive(:root).and_return(destination_root)

--- a/spec/lib/active_outbox/generators/model_generator_spec.rb
+++ b/spec/lib/active_outbox/generators/model_generator_spec.rb
@@ -26,11 +26,100 @@ RSpec.describe ActiveOutbox::Generators::ModelGenerator, type: :generator do
   end
   let(:timestamp_of_migration) { DateTime.now.in_time_zone('UTC').strftime('%Y%m%d%H%M%S') }
 
+  shared_examples 'creates the correct migrations for supported adapters' do
+    context 'when it is a mysql migration' do
+      before do
+        allow(ActiveOutbox::AdapterHelper).to receive_messages(postgres?: false, mysql?: true)
+      end
+
+      let(:expected_content) do
+        <<~MIGRATION
+          class ActiveOutboxCreate#{table_name.camelize}Outboxes < ActiveRecord::Migration[#{active_record_dependency}]
+            def change
+              create_table :#{table_name}#{table_name.blank? ? '' : '_'}outboxes do |t|
+                t.string :identifier, null: false, index: { unique: true }
+                t.string :event, null: false
+                t.json :payload
+                t.string :aggregate, null: false
+                t.#{aggregate_identifier_types[0]} :aggregate_identifier, null: false, index: true
+
+                t.timestamps
+              end
+            end
+          end
+        MIGRATION
+      end
+
+      it 'creates the migration with the correct content' do
+        generate
+        expect(actual_content).to include(expected_content)
+      end
+    end
+
+    context 'when it is a sqlite migration' do
+      before do
+        allow(ActiveOutbox::AdapterHelper).to receive_messages(postgres?: false, mysql?: false)
+      end
+
+      let(:expected_content) do
+        <<~MIGRATION
+          class ActiveOutboxCreate#{table_name.camelize}Outboxes < ActiveRecord::Migration[#{active_record_dependency}]
+            def change
+              create_table :#{table_name}#{table_name.blank? ? '' : '_'}outboxes do |t|
+                t.string :identifier, null: false, index: { unique: true }
+                t.string :event, null: false
+                t.string :payload
+                t.string :aggregate, null: false
+                t.#{aggregate_identifier_types[1]} :aggregate_identifier, null: false, index: true
+
+                t.timestamps
+              end
+            end
+          end
+        MIGRATION
+      end
+
+      it 'creates the migration with the correct content' do
+        generate
+        expect(actual_content).to include(expected_content)
+      end
+    end
+
+    context 'when it is a postgres migration' do
+      before do
+        allow(ActiveOutbox::AdapterHelper).to receive(:postgres?).and_return(true)
+      end
+
+      let(:expected_content) do
+        <<~MIGRATION
+          class ActiveOutboxCreate#{table_name.camelize}Outboxes < ActiveRecord::Migration[#{active_record_dependency}]
+            def change
+              create_table :#{table_name}#{table_name.blank? ? '' : '_'}outboxes do |t|
+                t.uuid :identifier, null: false, index: { unique: true }
+                t.string :event, null: false
+                t.jsonb :payload
+                t.string :aggregate, null: false
+                t.#{aggregate_identifier_types[2]} :aggregate_identifier, null: false, index: true
+
+                t.timestamps
+              end
+            end
+          end
+        MIGRATION
+      end
+
+      it 'creates the migration with the correct content' do
+        generate
+        expect(actual_content).to include(expected_content)
+      end
+    end
+  end
+
   context 'with default outbox name' do
     let(:migration_file_path) do
       "#{destination_root}/db/migrate/#{timestamp_of_migration}_active_outbox_create_outboxes.rb"
     end
-    
+
     context 'without root_component_path' do
       before do
         allow(Rails).to receive(:root).and_return(destination_root)
@@ -50,96 +139,23 @@ RSpec.describe ActiveOutbox::Generators::ModelGenerator, type: :generator do
     end
 
     describe 'migration content' do
-      subject(:generate) { run_generator(["--component_path=#{destination_root}"]) }
-
       let(:actual_content) { File.read(migration_file_path) }
       let(:active_record_dependency) { ActiveRecord::VERSION::STRING.to_f }
 
-      context 'when it is a mysql migration' do
-        before do
-          allow(ActiveOutbox::AdapterHelper).to receive_messages(postgres?: false, mysql?: true)
-        end
+      context 'with id aggregate_identifier' do
+        subject(:generate) { run_generator(["--component_path=#{destination_root}"]) }
 
-        let(:expected_content) do
-          <<~MIGRATION
-            class ActiveOutboxCreateOutboxes < ActiveRecord::Migration[#{active_record_dependency}]
-              def change
-                create_table :outboxes do |t|
-                  t.string :identifier, null: false, index: { unique: true }
-                  t.string :event, null: false
-                  t.json :payload
-                  t.string :aggregate, null: false
-                  t.string :aggregate_identifier, null: false, index: true
+        let(:aggregate_identifier_types) { %w[integer integer integer] }
 
-                  t.timestamps
-                end
-              end
-            end
-          MIGRATION
-        end
-
-        it 'creates the migration with the correct content' do
-          generate
-          expect(actual_content).to include(expected_content)
-        end
+        include_examples 'creates the correct migrations for supported adapters'
       end
 
-      context 'when it is a sqlite migration' do
-        before do
-          allow(ActiveOutbox::AdapterHelper).to receive_messages(postgres?: false, mysql?: false)
-        end
+      context 'with uuid aggregate_identifier' do
+        subject(:generate) { run_generator(["--component_path=#{destination_root}", '--uuid']) }
 
-        let(:expected_content) do
-          <<~MIGRATION
-            class ActiveOutboxCreateOutboxes < ActiveRecord::Migration[#{active_record_dependency}]
-              def change
-                create_table :outboxes do |t|
-                  t.string :identifier, null: false, index: { unique: true }
-                  t.string :event, null: false
-                  t.string :payload
-                  t.string :aggregate, null: false
-                  t.string :aggregate_identifier, null: false, index: true
+        let(:aggregate_identifier_types) { %w[string string uuid] }
 
-                  t.timestamps
-                end
-              end
-            end
-          MIGRATION
-        end
-
-        it 'creates the migration with the correct content' do
-          generate
-          expect(actual_content).to include(expected_content)
-        end
-      end
-
-      context 'when it is a postgres migration' do
-        before do
-          allow(ActiveOutbox::AdapterHelper).to receive(:postgres?).and_return(true)
-        end
-
-        let(:expected_content) do
-          <<~MIGRATION
-            class ActiveOutboxCreateOutboxes < ActiveRecord::Migration[#{active_record_dependency}]
-              def change
-                create_table :outboxes do |t|
-                  t.uuid :identifier, null: false, index: { unique: true }
-                  t.string :event, null: false
-                  t.jsonb :payload
-                  t.string :aggregate, null: false
-                  t.uuid :aggregate_identifier, null: false, index: true
-
-                  t.timestamps
-                end
-              end
-            end
-          MIGRATION
-        end
-
-        it 'creates the migration with the correct content' do
-          generate
-          expect(actual_content).to include(expected_content)
-        end
+        include_examples 'creates the correct migrations for supported adapters'
       end
     end
   end
@@ -166,96 +182,23 @@ RSpec.describe ActiveOutbox::Generators::ModelGenerator, type: :generator do
     end
 
     describe 'migration content' do
-      subject(:generate) { run_generator([table_name, "--component_path=#{destination_root}"]) }
-
       let(:actual_content) { File.read(migration_file_path) }
       let(:active_record_dependency) { ActiveRecord::VERSION::STRING.to_f }
 
-      context 'when it is a mysql migration' do
-        before do
-          allow(ActiveOutbox::AdapterHelper).to receive_messages(postgres?: false, mysql?: true)
-        end
+      context 'with id aggregate_identifier' do
+        subject(:generate) { run_generator([table_name, "--component_path=#{destination_root}"]) }
 
-        let(:expected_content) do
-          <<~MIGRATION
-            class ActiveOutboxCreate#{table_name.camelize}Outboxes < ActiveRecord::Migration[#{active_record_dependency}]
-              def change
-                create_table :#{table_name}_outboxes do |t|
-                  t.string :identifier, null: false, index: { unique: true }
-                  t.string :event, null: false
-                  t.json :payload
-                  t.string :aggregate, null: false
-                  t.string :aggregate_identifier, null: false, index: true
+        let(:aggregate_identifier_types) { %w[integer integer integer] }
 
-                  t.timestamps
-                end
-              end
-            end
-          MIGRATION
-        end
-
-        it 'creates the migration with the correct content' do
-          generate
-          expect(actual_content).to include(expected_content)
-        end
+        include_examples 'creates the correct migrations for supported adapters'
       end
 
-      context 'when it is a sqlite migration' do
-        before do
-          allow(ActiveOutbox::AdapterHelper).to receive_messages(postgres?: false, mysql?: false)
-        end
+      context 'with uuid aggregate_identifier' do
+        subject(:generate) { run_generator([table_name, "--component_path=#{destination_root}", '--uuid']) }
 
-        let(:expected_content) do
-          <<~MIGRATION
-            class ActiveOutboxCreate#{table_name.camelize}Outboxes < ActiveRecord::Migration[#{active_record_dependency}]
-              def change
-                create_table :#{table_name}_outboxes do |t|
-                  t.string :identifier, null: false, index: { unique: true }
-                  t.string :event, null: false
-                  t.string :payload
-                  t.string :aggregate, null: false
-                  t.string :aggregate_identifier, null: false, index: true
+        let(:aggregate_identifier_types) { %w[string string uuid] }
 
-                  t.timestamps
-                end
-              end
-            end
-          MIGRATION
-        end
-
-        it 'creates the migration with the correct content' do
-          generate
-          expect(actual_content).to include(expected_content)
-        end
-      end
-
-      context 'when it is a postgres migration' do
-        before do
-          allow(ActiveOutbox::AdapterHelper).to receive(:postgres?).and_return(true)
-        end
-
-        let(:expected_content) do
-          <<~MIGRATION
-            class ActiveOutboxCreate#{table_name.camelize}Outboxes < ActiveRecord::Migration[#{active_record_dependency}]
-              def change
-                create_table :#{table_name}_outboxes do |t|
-                  t.uuid :identifier, null: false, index: { unique: true }
-                  t.string :event, null: false
-                  t.jsonb :payload
-                  t.string :aggregate, null: false
-                  t.uuid :aggregate_identifier, null: false, index: true
-
-                  t.timestamps
-                end
-              end
-            end
-          MIGRATION
-        end
-
-        it 'creates the migration with the correct content' do
-          generate
-          expect(actual_content).to include(expected_content)
-        end
+        include_examples 'creates the correct migrations for supported adapters'
       end
     end
   end

--- a/spec/lib/active_outbox/outboxable_spec.rb
+++ b/spec/lib/active_outbox/outboxable_spec.rb
@@ -293,8 +293,8 @@ RSpec.describe ActiveOutbox::Outboxable do
   end
 
   context 'when model has default primary_key' do
-    let(:fake_model_class) { Id::FakeModel }
-    let(:outbox_class) { Id::Outbox }
+    let(:fake_model_class) { FakeModel }
+    let(:outbox_class) { Outbox }
     let(:identifier) { 2 }
     let(:new_identifier) { 6 }
     let(:test_field) { 'test' }

--- a/spec/lib/active_outbox/outboxable_spec.rb
+++ b/spec/lib/active_outbox/outboxable_spec.rb
@@ -3,13 +3,16 @@
 require 'spec_helper'
 
 RSpec.describe ActiveOutbox::Outboxable do
-  let(:fake_model_instance) { FakeModel.new(identifier: identifier) }
-  let(:identifier) { SecureRandom.uuid }
+  let(:fake_model_class) { double }
+  let(:outbox_class) { double }
+  let(:fake_model_instance) { double }
+  let(:identifier) { double }
+  let(:new_identifier) { double }
 
   let(:outbox_record_attributes) do
     {
       'event' => event,
-      'aggregate' => 'FakeModel',
+      'aggregate' => fake_model_instance.class.name,
       'aggregate_identifier' => aggregate_identifier,
       'payload' => {
         'before' => payload_before,
@@ -19,260 +22,301 @@ RSpec.describe ActiveOutbox::Outboxable do
   end
   let(:aggregate_identifier) { identifier }
   let(:payload_before) { nil }
-  let(:payload_after) { FakeModel.last.as_json }
+  let(:payload_after) { double }
 
   shared_examples 'creates the outbox record' do
-    it { expect { subject }.to change(Outbox, :count).by(1) }
+    it { expect { subject }.to change(outbox_class, :count).by(1) }
   end
 
   shared_examples 'creates the record and the outbox record' do
     include_examples 'creates the outbox record'
 
-    it { expect { subject }.to change(FakeModel, :count).by(1) }
+    it { expect { subject }.to change(fake_model_class, :count).by(1) }
   end
 
   shared_examples 'creates the outbox record with the correct data' do
-    it { expect { subject }.to create_outbox_record(Outbox).with_attributes(-> { outbox_record_attributes }) }
+    it { expect { subject }.to create_outbox_record(outbox_class).with_attributes(-> { outbox_record_attributes }) }
   end
 
   shared_examples 'updates the record' do
     specify do
-      expect { subject }.to not_change(FakeModel, :count)
-        .and change(fake_model_instance, :identifier).to(new_identifier)
+      expect { subject }.to not_change(fake_model_class, :count)
+        .and change(fake_model_instance, fake_model_class.primary_key).to(new_identifier)
     end
   end
 
   shared_examples 'does not create neither the record nor the outbox record' do
-    it { expect { subject }.not_to change(FakeModel, :count) }
-    it { expect { subject }.not_to change(Outbox, :count) }
+    it { expect { subject }.not_to change(fake_model_class, :count) }
+    it { expect { subject }.not_to change(outbox_class, :count) }
   end
 
   shared_examples 'raises an error and does not create neither the record nor the outbox record' do |error_class|
     it { expect { subject }.to raise_error(error_class) }
-    it { expect { subject }.to raise_error(error_class).and not_change(FakeModel, :count) }
-    it { expect { subject }.to raise_error(error_class).and not_change(Outbox, :count) }
+    it { expect { subject }.to raise_error(error_class).and not_change(fake_model_class, :count) }
+    it { expect { subject }.to raise_error(error_class).and not_change(outbox_class, :count) }
   end
 
-  describe '#save' do
-    subject(:save_instance) { fake_model_instance.save }
+  def create_event_name(action)
+    *namespace, klass = fake_model_class.name.underscore.upcase.split('/')
+    namespace = namespace.reverse.join('.')
+    event_name = "#{klass}_#{action.upcase}"
+    "#{event_name}#{namespace.blank? ? '' : '.'}#{namespace}"
+  end
 
-    context 'when record is created' do
-      context 'when the ActiveOutbox configuration is not set' do
-        before do
-          allow(ActiveOutbox.config).to receive(:outbox_mapping).and_return({ 'default' => nil })
+  shared_examples 'model CRUD' do
+    describe '#save' do
+      subject(:save_instance) { fake_model_instance.save }
+
+      context 'when record is created' do
+        context 'when the ActiveOutbox configuration is not set' do
+          before do
+            allow(ActiveOutbox.config).to receive(:outbox_mapping).and_return({ 'default' => nil })
+          end
+
+          include_examples 'raises an error and does not create neither the record nor the outbox record',
+            ActiveOutbox::OutboxClassNotFoundError
         end
 
-        include_examples 'raises an error and does not create neither the record nor the outbox record',
-                         ActiveOutbox::OutboxClassNotFoundError
-      end
+        context 'when outbox record is created' do
+          let(:event) { create_event_name('created') }
 
-      context 'when outbox record is created' do
-        let(:event) { 'FAKE_MODEL_CREATED' }
+          include_examples 'creates the record and the outbox record'
+          include_examples 'creates the outbox record with the correct data'
 
-        include_examples 'creates the record and the outbox record'
-        include_examples 'creates the outbox record with the correct data'
+          it { is_expected.to be true }
+        end
 
-        it { is_expected.to be true }
-      end
-
-      context 'when there is a record invalid error when creating the outbox record' do
-        before do
-          payload = {
-            before: nil,
-            after: {
-              id: 1,
-              identifier: '7d8f60e3-5e7f-4c11-b18b-5cc01ceea3da'
+        context 'when there is a record invalid error when creating the outbox record' do
+          before do
+            payload = {
+              before: nil,
+              after: {
+                id: 1,
+                identifier: '7d8f60e3-5e7f-4c11-b18b-5cc01ceea3da'
+              }
             }
-          }
 
-          outbox = Outbox.new(
-            identifier: SecureRandom.uuid,
-            event: nil,
-            payload: payload,
-            aggregate: FakeModel.name,
-            aggregate_identifier: fake_model_instance.identifier
-          )
+            outbox = outbox_class.new(
+              identifier: SecureRandom.uuid,
+              event: nil,
+              payload: payload,
+              aggregate: fake_model_class.name,
+              aggregate_identifier: fake_model_instance.send(fake_model_class.primary_key)
+            )
 
-          allow(Outbox).to receive(:new).and_return(outbox)
+            allow(outbox_class).to receive(:new).and_return(outbox)
+          end
+
+          include_examples 'does not create neither the record nor the outbox record'
+
+          it { is_expected.to be false }
+
+          it 'adds the errors to the model' do
+            expect { save_instance }.to change {
+              fake_model_instance.errors.messages
+            }.from({}).to({ 'outbox.event': ["can't be blank"] })
+          end
         end
+
+        context 'when there is an error when creating the outbox record' do
+          before do
+            outbox = instance_double(outbox_class, invalid?: false)
+            allow(outbox_class).to receive(:new).and_return(outbox)
+            allow(outbox).to receive(:save!).and_raise(ActiveRecord::RecordNotSaved)
+          end
+
+          include_examples 'raises an error and does not create neither the record nor the outbox record',
+            ActiveRecord::RecordNotSaved
+        end
+      end
+
+      context 'when the record could not be created' do
+        let(:test_field) { nil }
 
         include_examples 'does not create neither the record nor the outbox record'
 
         it { is_expected.to be false }
-
-        it 'adds the errors to the model' do
-          expect { save_instance }.to change {
-            fake_model_instance.errors.messages
-          }.from({}).to({ 'outbox.event': ["can't be blank"] })
-        end
       end
 
-      context 'when there is an error when creating the outbox record' do
-        before do
-          outbox = instance_double(Outbox, invalid?: false)
-          allow(Outbox).to receive(:new).and_return(outbox)
-          allow(outbox).to receive(:save!).and_raise(ActiveRecord::RecordNotSaved)
+      context 'when record is updated' do
+        subject(:save_instance) do
+          fake_model_instance.send("#{fake_model_class.primary_key}=", new_identifier)
+          fake_model_instance.save
         end
 
-        include_examples 'raises an error and does not create neither the record nor the outbox record',
-                         ActiveRecord::RecordNotSaved
+        let(:fake_model_instance) do
+          fake_model_class.create("#{fake_model_class.primary_key}": identifier, test_field: test_field)
+        end
+
+        context 'when outbox record is created' do
+          let(:event) { create_event_name('updated') }
+          let(:aggregate_identifier) { new_identifier }
+          let(:payload_before) { fake_model_instance.as_json }
+
+          before { payload_before }
+
+          include_examples 'creates the outbox record'
+          include_examples 'creates the outbox record with the correct data'
+          include_examples 'updates the record'
+
+          it { is_expected.to be true }
+        end
       end
     end
 
-    context 'when the record could not be created' do
-      let(:identifier) { nil }
+    describe '#save!' do
+      subject(:bang_save_instance) { fake_model_instance.save! }
 
-      include_examples 'does not create neither the record nor the outbox record'
+      context 'when record is created' do
+        context 'when outbox record is created' do
+          include_examples 'creates the record and the outbox record'
 
-      it { is_expected.to be false }
-    end
-
-    context 'when record is updated' do
-      subject(:save_instance) do
-        fake_model_instance.identifier = new_identifier
-        fake_model_instance.save
-      end
-
-      let(:fake_model_instance) { FakeModel.create(identifier: identifier) }
-
-      context 'when outbox record is created' do
-        let(:event) { 'FAKE_MODEL_UPDATED' }
-        let(:aggregate_identifier) { new_identifier }
-        let(:payload_before) { fake_model_instance.as_json }
-
-        before { payload_before }
-
-        include_examples 'creates the outbox record'
-        include_examples 'creates the outbox record with the correct data'
-        include_examples 'updates the record' do
-          let(:new_identifier) { SecureRandom.uuid }
+          it { is_expected.to be true }
         end
 
-        it { is_expected.to be true }
-      end
-    end
-  end
-
-  describe '#save!' do
-    subject(:bang_save_instance) { fake_model_instance.save! }
-
-    context 'when record is created' do
-      context 'when outbox record is created' do
-        include_examples 'creates the record and the outbox record'
-
-        it { is_expected.to be true }
-      end
-
-      context 'when there is a record invalid error when creating the outbox record' do
-        before do
-          payload = {
-            before: nil,
-            after: {
-              id: 1,
-              identifier: '7d8f60e3-5e7f-4c11-b18b-5cc01ceea3da'
+        context 'when there is a record invalid error when creating the outbox record' do
+          before do
+            payload = {
+              before: nil,
+              after: {
+                id: 1,
+                identifier: '7d8f60e3-5e7f-4c11-b18b-5cc01ceea3da'
+              }
             }
-          }
 
-          outbox = Outbox.new(
-            identifier: SecureRandom.uuid,
-            event: nil,
-            payload: payload,
-            aggregate: FakeModel.name,
-            aggregate_identifier: fake_model_instance.identifier
-          )
+            outbox = outbox_class.new(
+              identifier: SecureRandom.uuid,
+              event: nil,
+              payload: payload,
+              aggregate: fake_model_class.name,
+              aggregate_identifier: fake_model_instance.send(fake_model_class.primary_key)
+            )
 
-          allow(Outbox).to receive(:new).and_return(outbox)
+            allow(outbox_class).to receive(:new).and_return(outbox)
+          end
+
+          include_examples 'raises an error and does not create neither the record nor the outbox record',
+            ActiveRecord::RecordInvalid
+
+          it 'adds the errors to the model' do
+            expect { bang_save_instance }.to raise_error(ActiveRecord::RecordInvalid)
+              .and change { fake_model_instance.errors.messages }.from({}).to({ 'outbox.event': ["can't be blank"] })
+          end
         end
+
+        context 'when there is an error when creating the outbox record' do
+          before do
+            outbox = instance_double(outbox_class, invalid?: false)
+            allow(outbox_class).to receive(:new).and_return(outbox)
+            allow(outbox).to receive(:save!).and_raise(ActiveRecord::RecordNotSaved)
+          end
+
+          include_examples 'raises an error and does not create neither the record nor the outbox record',
+            ActiveRecord::RecordNotSaved
+        end
+      end
+
+      context 'when the record could not be created' do
+        let(:test_field) { nil }
 
         include_examples 'raises an error and does not create neither the record nor the outbox record',
-                         ActiveRecord::RecordInvalid
-
-        it 'adds the errors to the model' do
-          expect { bang_save_instance }.to raise_error(ActiveRecord::RecordInvalid)
-            .and change { fake_model_instance.errors.messages }.from({}).to({ 'outbox.event': ["can't be blank"] })
-        end
-      end
-
-      context 'when there is an error when creating the outbox record' do
-        before do
-          outbox = instance_double(Outbox, invalid?: false)
-          allow(Outbox).to receive(:new).and_return(outbox)
-          allow(outbox).to receive(:save!).and_raise(ActiveRecord::RecordNotSaved)
-        end
-
-        include_examples 'raises an error and does not create neither the record nor the outbox record',
-                         ActiveRecord::RecordNotSaved
+          ActiveRecord::RecordInvalid
       end
     end
 
-    context 'when the record could not be created' do
-      let(:identifier) { nil }
+    describe '#create' do
+      subject(:create_instance) do
+        fake_model_class.create("#{fake_model_class.primary_key}": identifier, test_field: test_field)
+      end
 
-      include_examples 'raises an error and does not create neither the record nor the outbox record',
-                       ActiveRecord::RecordInvalid
+      context 'when record is created' do
+        context 'when outbox record is created' do
+          let(:event) { create_event_name('created') }
+
+          include_examples 'creates the record and the outbox record'
+          include_examples 'creates the outbox record with the correct data'
+
+          it { is_expected.to eq(fake_model_class.last) }
+        end
+      end
+    end
+
+    describe '#update' do
+      subject(:update_instance) { fake_model_instance.update("#{fake_model_class.primary_key}": new_identifier) }
+
+      let!(:fake_model_instance) do
+        fake_model_class.create("#{fake_model_class.primary_key}": identifier, test_field: test_field)
+      end
+
+      context 'when record is updated' do
+        context 'when outbox record is created' do
+          let(:event) { create_event_name('updated') }
+          let(:aggregate_identifier) { new_identifier }
+          let(:payload_before) { fake_model_instance.as_json }
+          let(:payload_after) { fake_model_instance.reload.as_json }
+
+          before { payload_before }
+
+          include_examples 'creates the outbox record'
+          include_examples 'creates the outbox record with the correct data'
+          include_examples 'updates the record'
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    describe '#destroy' do
+      subject(:destroy_instance) { fake_model_instance.destroy }
+
+      let!(:fake_model_instance) do
+        fake_model_class.create("#{fake_model_class.primary_key}": identifier, test_field: test_field)
+      end
+
+      context 'when record is destroyed' do
+        context 'when outbox record is created' do
+          let(:event) { create_event_name('destroyed') }
+          let(:payload_before) { fake_model_instance.as_json }
+          let(:payload_after) { nil }
+
+          include_examples 'creates the outbox record'
+          include_examples 'creates the outbox record with the correct data'
+
+          it { is_expected.to eq(fake_model_instance) }
+
+          it 'destroys the record' do
+            expect { destroy_instance }.to change(fake_model_class, :count).by(-1)
+          end
+        end
+      end
     end
   end
 
-  describe '#create' do
-    subject(:create_instance) { FakeModel.create(identifier: identifier) }
-
-    context 'when record is created' do
-      context 'when outbox record is created' do
-        let(:event) { 'FAKE_MODEL_CREATED' }
-
-        include_examples 'creates the record and the outbox record'
-        include_examples 'creates the outbox record with the correct data'
-
-        it { is_expected.to eq(FakeModel.last) }
-      end
+  context 'when model has default primary_key' do
+    let(:fake_model_class) { Id::FakeModel }
+    let(:outbox_class) { Id::Outbox }
+    let(:identifier) { 2 }
+    let(:new_identifier) { 6 }
+    let(:test_field) { 'test' }
+    let(:fake_model_instance) do
+      fake_model_class.new("#{fake_model_class.primary_key}": identifier, test_field: test_field)
     end
+    let(:payload_after) { fake_model_class.last.as_json }
+
+    include_examples 'model CRUD'
   end
 
-  describe '#update' do
-    subject(:update_instance) { fake_model_instance.update(identifier: new_identifier) }
-
-    let!(:fake_model_instance) { FakeModel.create(identifier: identifier) }
-
-    context 'when record is updated' do
-      context 'when outbox record is created' do
-        let(:event) { 'FAKE_MODEL_UPDATED' }
-        let(:aggregate_identifier) { new_identifier }
-        let(:payload_before) { fake_model_instance.as_json }
-        let(:payload_after) { fake_model_instance.reload.as_json }
-
-        before { payload_before }
-
-        include_examples 'creates the outbox record'
-        include_examples 'creates the outbox record with the correct data'
-        include_examples 'updates the record' do
-          let(:new_identifier) { SecureRandom.uuid }
-        end
-
-        it { is_expected.to be true }
-      end
+  context 'when model has custom uuid primary_key' do
+    let(:fake_model_class) { Uuid::FakeModel }
+    let(:outbox_class) { Uuid::Outbox }
+    let(:identifier) { 'bbdfa748-d1c4-4dc0-98d2-2246f10b5c9a' }
+    let(:new_identifier) { '1fad4ed8-8d86-4661-b113-621f271a6956' }
+    let(:test_field) { 'test' }
+    let(:fake_model_instance) do
+      fake_model_class.new("#{fake_model_class.primary_key}": identifier, test_field: test_field)
     end
-  end
+    let(:payload_after) { fake_model_class.last.as_json }
 
-  describe '#destroy' do
-    subject(:destroy_instance) { fake_model_instance.destroy }
-
-    let!(:fake_model_instance) { FakeModel.create(identifier: identifier) }
-
-    context 'when record is destroyed' do
-      context 'when outbox record is created' do
-        let(:event) { 'FAKE_MODEL_DESTROYED' }
-        let(:payload_before) { fake_model_instance.as_json }
-        let(:payload_after) { nil }
-
-        include_examples 'creates the outbox record'
-        include_examples 'creates the outbox record with the correct data'
-
-        it { is_expected.to eq(fake_model_instance) }
-
-        it 'destroys the record' do
-          expect { destroy_instance }.to change(FakeModel, :count).by(-1)
-        end
-      end
-    end
+    include_examples 'model CRUD'
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,80 +18,31 @@ end
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
-db_config = if ENV['ADAPTER'] == 'postgresql'
-              {
-                adapter: 'postgresql',
-                username: ENV.fetch('POSTGRES_USER', nil),
-                host: ENV.fetch('POSTGRES_HOST', nil),
-                port: ENV.fetch('POSTGRES_PORT', nil)
-              }
-            elsif ENV['ADAPTER'] == 'mysql2'
-              {
-                adapter: 'mysql2',
-                username: ENV.fetch('MYSQL_USER', nil),
-                host: ENV.fetch('MYSQL_HOST', nil),
-                port: ENV.fetch('MYSQL_PORT', nil),
-                password: ENV.fetch('MYSQL_PASSWORD', nil),
-                database: ENV.fetch('MYSQL_DATABASE', nil)
-              }
-            else
-              {
-                adapter: 'sqlite3',
-                database: ':memory:'
-              }
-            end
+db_config =
+  if ENV['ADAPTER'] == 'postgresql'
+    {
+      adapter: 'postgresql',
+      username: ENV.fetch('POSTGRES_USER', nil),
+      host: ENV.fetch('POSTGRES_HOST', nil),
+      port: ENV.fetch('POSTGRES_PORT', nil)
+    }
+  elsif ENV['ADAPTER'] == 'mysql2'
+    {
+      adapter: 'mysql2',
+      username: ENV.fetch('MYSQL_USER', nil),
+      host: ENV.fetch('MYSQL_HOST', nil),
+      port: ENV.fetch('MYSQL_PORT', nil),
+      password: ENV.fetch('MYSQL_PASSWORD', nil),
+      database: ENV.fetch('MYSQL_DATABASE', nil)
+    }
+  else
+    {
+      adapter: 'sqlite3',
+      database: ':memory:'
+    }
+  end
+
 ActiveRecord::Base.establish_connection(**db_config)
-Object.const_set('Uuid', Module.new)
-Object.const_set('Id', Module.new)
-Uuid::Outbox = Class.new(ActiveRecord::Base) do
-  def self.name
-    'Uuid::Outbox'
-  end
-
-  def self.table_name
-    'uuid_outboxes'
-  end
-
-  validates_presence_of :identifier, :payload, :aggregate, :aggregate_identifier, :event
-end
-
-Id::Outbox = Class.new(ActiveRecord::Base) do
-  def self.name
-    'Id::Outbox'
-  end
-
-  def self.table_name
-    'id_outboxes'
-  end
-
-  validates_presence_of :identifier, :payload, :aggregate, :aggregate_identifier, :event
-end
-
-Uuid::FakeModel = Class.new(ActiveRecord::Base) do
-  def self.name
-    'Uuid::FakeModel'
-  end
-
-  def self.table_name
-    'uuid_fake_models'
-  end
-
-  validates_presence_of :test_field
-  include ActiveOutbox::Outboxable
-end
-
-Id::FakeModel = Class.new(ActiveRecord::Base) do
-  def self.name
-    'Id::FakeModel'
-  end
-
-  def self.table_name
-    'id_fake_models'
-  end
-
-  validates_presence_of :test_field
-  include ActiveOutbox::Outboxable
-end
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -107,33 +58,7 @@ RSpec.configure do |config|
   config.include OutboxableTestHelpers
 
   config.before(:suite) do
-    ActiveRecord::Base.connection.create_table :uuid_fake_models,
-      if_not_exists: true,
-      primary_key: :identifier,
-      id: :uuid do |t|
-      t.string :test_field
-    end
-    ActiveRecord::Base.connection.create_table :id_fake_models, if_not_exists: true do |t|
-      t.string :test_field
-    end
-    ActiveRecord::Base.connection.create_table :uuid_outboxes, if_not_exists: true do |t|
-      t.send(ActiveOutbox::AdapterHelper.uuid_type, :identifier, null: false, index: { unique: true })
-      t.string :event, null: false
-      t.send(ActiveOutbox::AdapterHelper.json_type, :payload)
-      t.string :aggregate, null: false
-      t.send(ActiveOutbox::AdapterHelper.uuid_type, :aggregate_identifier, null: false)
-
-      t.timestamps
-    end
-    ActiveRecord::Base.connection.create_table :id_outboxes, if_not_exists: true do |t|
-      t.send(ActiveOutbox::AdapterHelper.uuid_type, :identifier, null: false, index: { unique: true })
-      t.string :event, null: false
-      t.send(ActiveOutbox::AdapterHelper.json_type, :payload)
-      t.string :aggregate, null: false
-      t.integer :aggregate_identifier, null: false
-
-      t.timestamps
-    end
+    create_migrations
   end
 
   config.before(:suite) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require 'active_record'
 require 'byebug'
 require 'database_cleaner/active_record'
 require 'simplecov'
+require 'super_diff/rspec'
 
 SimpleCov.start 'rails' do
   add_filter 'spec/'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,22 +41,56 @@ db_config = if ENV['ADAPTER'] == 'postgresql'
               }
             end
 ActiveRecord::Base.establish_connection(**db_config)
-
-Outbox = Class.new(ActiveRecord::Base) do
+Object.const_set('Uuid', Module.new)
+Object.const_set('Id', Module.new)
+Uuid::Outbox = Class.new(ActiveRecord::Base) do
   def self.name
-    'Outbox'
+    'Uuid::Outbox'
+  end
+
+  def self.table_name
+    'uuid_outboxes'
   end
 
   validates_presence_of :identifier, :payload, :aggregate, :aggregate_identifier, :event
 end
 
-FakeModel = Class.new(ActiveRecord::Base) do
+Id::Outbox = Class.new(ActiveRecord::Base) do
   def self.name
-    'FakeModel'
+    'Id::Outbox'
   end
 
+  def self.table_name
+    'id_outboxes'
+  end
+
+  validates_presence_of :identifier, :payload, :aggregate, :aggregate_identifier, :event
+end
+
+Uuid::FakeModel = Class.new(ActiveRecord::Base) do
+  def self.name
+    'Uuid::FakeModel'
+  end
+
+  def self.table_name
+    'uuid_fake_models'
+  end
+
+  validates_presence_of :test_field
   include ActiveOutbox::Outboxable
-  validates :identifier, presence: true
+end
+
+Id::FakeModel = Class.new(ActiveRecord::Base) do
+  def self.name
+    'Id::FakeModel'
+  end
+
+  def self.table_name
+    'id_fake_models'
+  end
+
+  validates_presence_of :test_field
+  include ActiveOutbox::Outboxable
 end
 
 RSpec.configure do |config|
@@ -73,16 +107,30 @@ RSpec.configure do |config|
   config.include OutboxableTestHelpers
 
   config.before(:suite) do
-    ActiveRecord::Base.connection.create_table :fake_models, if_not_exists: true do |t|
-      t.string :identifier, null: false
+    ActiveRecord::Base.connection.create_table :uuid_fake_models,
+      if_not_exists: true,
+      primary_key: :identifier,
+      id: :uuid do |t|
+      t.string :test_field
     end
-
-    ActiveRecord::Base.connection.create_table :outboxes, if_not_exists: true do |t|
+    ActiveRecord::Base.connection.create_table :id_fake_models, if_not_exists: true do |t|
+      t.string :test_field
+    end
+    ActiveRecord::Base.connection.create_table :uuid_outboxes, if_not_exists: true do |t|
       t.send(ActiveOutbox::AdapterHelper.uuid_type, :identifier, null: false, index: { unique: true })
       t.string :event, null: false
       t.send(ActiveOutbox::AdapterHelper.json_type, :payload)
       t.string :aggregate, null: false
       t.send(ActiveOutbox::AdapterHelper.uuid_type, :aggregate_identifier, null: false)
+
+      t.timestamps
+    end
+    ActiveRecord::Base.connection.create_table :id_outboxes, if_not_exists: true do |t|
+      t.send(ActiveOutbox::AdapterHelper.uuid_type, :identifier, null: false, index: { unique: true })
+      t.string :event, null: false
+      t.send(ActiveOutbox::AdapterHelper.json_type, :payload)
+      t.string :aggregate, null: false
+      t.integer :aggregate_identifier, null: false
 
       t.timestamps
     end

--- a/spec/support/00_outbox_config.rb
+++ b/spec/support/00_outbox_config.rb
@@ -2,6 +2,7 @@
 
 ActiveOutbox.configure do |config|
   config.outbox_mapping.merge!(
-    'default' => 'Outbox'
+    'id' => 'Id::Outbox',
+    'uuid' => 'Uuid::Outbox'
   )
 end

--- a/spec/support/00_outbox_config.rb
+++ b/spec/support/00_outbox_config.rb
@@ -2,7 +2,7 @@
 
 ActiveOutbox.configure do |config|
   config.outbox_mapping.merge!(
-    'id' => 'Id::Outbox',
+    'default' => 'Outbox',
     'uuid' => 'Uuid::Outbox'
   )
 end

--- a/spec/support/outbox_models.rb
+++ b/spec/support/outbox_models.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Object.const_set('Uuid', Module.new)
-Object.const_set('Id', Module.new)
+
 Uuid::Outbox = Class.new(ActiveRecord::Base) do
   def self.name
     'Uuid::Outbox'
@@ -14,13 +14,9 @@ Uuid::Outbox = Class.new(ActiveRecord::Base) do
   validates_presence_of :identifier, :payload, :aggregate, :aggregate_identifier, :event
 end
 
-Id::Outbox = Class.new(ActiveRecord::Base) do
+Outbox = Class.new(ActiveRecord::Base) do
   def self.name
-    'Id::Outbox'
-  end
-
-  def self.table_name
-    'id_outboxes'
+    'Outbox'
   end
 
   validates_presence_of :identifier, :payload, :aggregate, :aggregate_identifier, :event
@@ -39,13 +35,9 @@ Uuid::FakeModel = Class.new(ActiveRecord::Base) do
   include ActiveOutbox::Outboxable
 end
 
-Id::FakeModel = Class.new(ActiveRecord::Base) do
+FakeModel = Class.new(ActiveRecord::Base) do
   def self.name
-    'Id::FakeModel'
-  end
-
-  def self.table_name
-    'id_fake_models'
+    'FakeModel'
   end
 
   validates_presence_of :test_field
@@ -58,11 +50,11 @@ def create_migrations
 end
 
 def id_migrations
-  ActiveRecord::Base.connection.create_table :id_fake_models, if_not_exists: true do |t|
+  ActiveRecord::Base.connection.create_table :fake_models, if_not_exists: true do |t|
     t.string :test_field
   end
 
-  ActiveRecord::Base.connection.create_table :id_outboxes, if_not_exists: true do |t|
+  ActiveRecord::Base.connection.create_table :outboxes, if_not_exists: true do |t|
     t.send(ActiveOutbox::AdapterHelper.uuid_type, :identifier, null: false, index: { unique: true })
     t.string :event, null: false
     t.send(ActiveOutbox::AdapterHelper.json_type, :payload)

--- a/spec/support/outbox_models.rb
+++ b/spec/support/outbox_models.rb
@@ -74,10 +74,8 @@ def id_migrations
 end
 
 def uuid_migrations
-  ActiveRecord::Base.connection.create_table :uuid_fake_models,
-    if_not_exists: true,
-    primary_key: :identifier,
-    id: :uuid do |t|
+  ActiveRecord::Base.connection.create_table :uuid_fake_models, if_not_exists: true, id: false do |t|
+    t.send(ActiveOutbox::AdapterHelper.uuid_type, :identifier, primary_key: true)
     t.string :test_field
   end
 

--- a/spec/support/outbox_models.rb
+++ b/spec/support/outbox_models.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+Object.const_set('Uuid', Module.new)
+Object.const_set('Id', Module.new)
+Uuid::Outbox = Class.new(ActiveRecord::Base) do
+  def self.name
+    'Uuid::Outbox'
+  end
+
+  def self.table_name
+    'uuid_outboxes'
+  end
+
+  validates_presence_of :identifier, :payload, :aggregate, :aggregate_identifier, :event
+end
+
+Id::Outbox = Class.new(ActiveRecord::Base) do
+  def self.name
+    'Id::Outbox'
+  end
+
+  def self.table_name
+    'id_outboxes'
+  end
+
+  validates_presence_of :identifier, :payload, :aggregate, :aggregate_identifier, :event
+end
+
+Uuid::FakeModel = Class.new(ActiveRecord::Base) do
+  def self.name
+    'Uuid::FakeModel'
+  end
+
+  def self.table_name
+    'uuid_fake_models'
+  end
+
+  validates_presence_of :test_field
+  include ActiveOutbox::Outboxable
+end
+
+Id::FakeModel = Class.new(ActiveRecord::Base) do
+  def self.name
+    'Id::FakeModel'
+  end
+
+  def self.table_name
+    'id_fake_models'
+  end
+
+  validates_presence_of :test_field
+  include ActiveOutbox::Outboxable
+end
+
+def create_migrations
+  id_migrations
+  uuid_migrations
+end
+
+def id_migrations
+  ActiveRecord::Base.connection.create_table :id_fake_models, if_not_exists: true do |t|
+    t.string :test_field
+  end
+
+  ActiveRecord::Base.connection.create_table :id_outboxes, if_not_exists: true do |t|
+    t.send(ActiveOutbox::AdapterHelper.uuid_type, :identifier, null: false, index: { unique: true })
+    t.string :event, null: false
+    t.send(ActiveOutbox::AdapterHelper.json_type, :payload)
+    t.string :aggregate, null: false
+    t.integer :aggregate_identifier, null: false
+
+    t.timestamps
+  end
+end
+
+def uuid_migrations
+  ActiveRecord::Base.connection.create_table :uuid_fake_models,
+    if_not_exists: true,
+    primary_key: :identifier,
+    id: :uuid do |t|
+    t.string :test_field
+  end
+
+  ActiveRecord::Base.connection.create_table :uuid_outboxes, if_not_exists: true do |t|
+    t.send(ActiveOutbox::AdapterHelper.uuid_type, :identifier, null: false, index: { unique: true })
+    t.string :event, null: false
+    t.send(ActiveOutbox::AdapterHelper.json_type, :payload)
+    t.string :aggregate, null: false
+    t.send(ActiveOutbox::AdapterHelper.uuid_type, :aggregate_identifier, null: false)
+
+    t.timestamps
+  end
+end


### PR DESCRIPTION
Problem was that when the records where using IDs as the primary_key, when generating the outbox record it would fail because the migration specified that field to be UUID.

- Added a flag to specify if we want that field to be UUID in the migration, default to ID now.
- Refactored specs to use shared_examples so it's cleaner to test more scenarios.
  - Had to play a little bit with the specs setup so we could have a table with UUID and ID.
- Fixed issue with the config mapping where we were setting the namespace incorrectly.
  -  Now we can set it with lowercase and underscore. 'UserAccess' => 'user_access'

Not sure if this should be a minor version bump to 0.2.0. Open to suggestions.