### PR TITLE
Fix an issue with finding the Events module for namespaced models

### DIFF
--- a/lib/active_outbox/outboxable.rb
+++ b/lib/active_outbox/outboxable.rb
@@ -10,7 +10,7 @@ module ActiveOutbox
       *namespace, klass = name.underscore.upcase.split('/')
       namespace = namespace.reverse.join('.')
 
-      module_parent.const_set('Events', Module.new) unless module_parent.const_defined?('Events')
+      module_parent.const_set('Events', Module.new) unless module_parent.const_defined?('Events', false)
 
       { create: 'CREATED', update: 'UPDATED', destroy: 'DESTROYED' }.each do |key, value|
         const_name = "#{klass}_#{value}"

--- a/lib/active_outbox/outboxable.rb
+++ b/lib/active_outbox/outboxable.rb
@@ -10,16 +10,19 @@ module ActiveOutbox
       *namespace, klass = name.underscore.upcase.split('/')
       namespace = namespace.reverse.join('.')
 
-      module_parent.const_set('Events', Module.new) unless module_parent.const_defined?('Events', false)
+      module_parent.const_set('ActiveOutboxEvents', Module.new) unless module_parent.const_defined?(
+        'ActiveOutboxEvents', false
+      )
 
       { create: 'CREATED', update: 'UPDATED', destroy: 'DESTROYED' }.each do |key, value|
         const_name = "#{klass}_#{value}"
 
-        unless module_parent::Events.const_defined?(const_name)
-          module_parent::Events.const_set(const_name, "#{const_name}#{namespace.blank? ? '' : '.'}#{namespace}")
+        unless module_parent::ActiveOutboxEvents.const_defined?(const_name)
+          module_parent::ActiveOutboxEvents.const_set(const_name,
+            "#{const_name}#{namespace.blank? ? '' : '.'}#{namespace}")
         end
 
-        event_name = module_parent::Events.const_get(const_name)
+        event_name = module_parent::ActiveOutboxEvents.const_get(const_name)
 
         send("after_#{key}") { create_outbox!(key, event_name) }
       end

--- a/spec/support/outbox_models.rb
+++ b/spec/support/outbox_models.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Object.const_set('Uuid', Module.new)
+Object.const_set('Events', Module.new)
 
 Uuid::Outbox = Class.new(ActiveRecord::Base) do
   def self.name

--- a/spec/support/outbox_models.rb
+++ b/spec/support/outbox_models.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Object.const_set('Uuid', Module.new)
-Object.const_set('Events', Module.new)
 
 Uuid::Outbox = Class.new(ActiveRecord::Base) do
   def self.name
@@ -23,6 +22,15 @@ Outbox = Class.new(ActiveRecord::Base) do
   validates_presence_of :identifier, :payload, :aggregate, :aggregate_identifier, :event
 end
 
+FakeModel = Class.new(ActiveRecord::Base) do
+  def self.name
+    'FakeModel'
+  end
+
+  validates_presence_of :test_field
+  include ActiveOutbox::Outboxable
+end
+
 Uuid::FakeModel = Class.new(ActiveRecord::Base) do
   def self.name
     'Uuid::FakeModel'
@@ -30,15 +38,6 @@ Uuid::FakeModel = Class.new(ActiveRecord::Base) do
 
   def self.table_name
     'uuid_fake_models'
-  end
-
-  validates_presence_of :test_field
-  include ActiveOutbox::Outboxable
-end
-
-FakeModel = Class.new(ActiveRecord::Base) do
-  def self.name
-    'FakeModel'
   end
 
   validates_presence_of :test_field


### PR DESCRIPTION
Hi, I ran into an issue when trying to use this with a model nested under a namespace. Things seemed to work in general, even for the model which raised the issue, but when running our unit test suite, the first test (of any kind) would always fail with `NameError: uninitialized constant Namespace::ModelName`. This appears to fix that. Let me know if you want a test case for this; when I get some time I can probably recreate the problem in a unit test.