### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 gem 'byebug', '~> 11.1.3'
 gem 'database_cleaner-active_record', '~> 2.1.0'
 gem 'generator_spec', '~> 0.9.4'
-gem 'mysql2', '~> 0.5.2'
+gem 'mysql2', '~> 0.5.6'
 gem 'pg', '~> 1.5.4'
 gem 'pry-rails', '~> 0.3.9'
 gem 'reek', '~> 6.1.4'
@@ -15,5 +15,5 @@ gem 'rspec', '~> 3.12.0'
 gem 'rubocop', '~> 1.56.3', require: false
 gem 'rubocop-rspec', '~> 2.24.1', require: false
 gem 'simplecov', '~> 0.22.0'
-gem 'sqlite3', '1.4.2'
+gem 'sqlite3', '1.5.0'
 gem 'super_diff', '~> 0.10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_outbox (0.2.0)
+    active_outbox (0.2.1)
       dry-configurable (~> 1.0)
       rails (>= 6.1)
 
@@ -135,7 +135,7 @@ GEM
     mini_portile2 (2.8.6)
     minitest (5.22.3)
     mutex_m (0.2.0)
-    mysql2 (0.5.5)
+    mysql2 (0.5.6)
     net-imap (0.4.4)
       date
       net-protocol
@@ -257,7 +257,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sqlite3 (1.4.2)
+    sqlite3 (1.5.0)
+      mini_portile2 (~> 2.8.0)
     stringio (3.1.0)
     strscan (3.1.0)
     super_diff (0.10.0)
@@ -283,7 +284,7 @@ DEPENDENCIES
   byebug (~> 11.1.3)
   database_cleaner-active_record (~> 2.1.0)
   generator_spec (~> 0.9.4)
-  mysql2 (~> 0.5.2)
+  mysql2 (~> 0.5.6)
   pg (~> 1.5.4)
   pry-rails (~> 0.3.9)
   reek (~> 6.1.4)
@@ -291,7 +292,7 @@ DEPENDENCIES
   rubocop (~> 1.56.3)
   rubocop-rspec (~> 2.24.1)
   simplecov (~> 0.22.0)
-  sqlite3 (= 1.4.2)
+  sqlite3 (= 1.5.0)
   super_diff (~> 0.10.0)
 
 BUNDLED WITH

--- a/active_outbox.gemspec
+++ b/active_outbox.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |spec|
   spec.files                 = Dir['LICENSE.txt', 'README.md', 'lib/**/*', 'lib/active_outbox.rb']
   spec.name                  = 'active_outbox'
   spec.summary               = 'A Transactional Outbox implementation for ActiveRecord'
-  spec.version               = '0.2.0'
+  spec.version               = '0.2.1'
 
   spec.email                 = 'guillermoaguirre1@gmail.com'
   spec.executables           = ['outbox']


### PR DESCRIPTION
Given the recent dependabot version upgrades figured we needed to bump the version to 0.2.1.
Also faced some issues with the versions for sqlite3 and mysql2 that needed upgrading.
See [sqlite3](https://github.com/sparklemotion/sqlite3-ruby/issues/313) & [mysql2](https://github.com/rails/rails/pull/51440)